### PR TITLE
Add root element guard in entry point

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,9 +4,14 @@ import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 
-const root = ReactDOM.createRoot(
-  document.getElementById('root') as HTMLElement
-);
+const container = document.getElementById('root');
+
+if (!container) {
+  throw new Error('Root container missing');
+}
+
+const root = ReactDOM.createRoot(container);
+
 root.render(
   <React.StrictMode>
     <App />


### PR DESCRIPTION
## Summary
- avoid runtime crash by checking for missing root element before rendering

## Testing
- `CI=true npm test -- --passWithNoTests`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a566979e988322872061a69d575b41