### PR TITLE
fix: render solution content

### DIFF
--- a/src/NetSuite.tsx
+++ b/src/NetSuite.tsx
@@ -266,8 +266,13 @@ const NetSuite = () => {
         navigate(routes[index]);
       }}
     >
-      <div className="relative overflow-hidden rounded-2xl bg-gradient-to-br from-white to-sky-50 border border-slate-200 hover:border-sky-400 transition-all duration-300 shadow-lg hover:shadow-xl">
-        ...（既存のコード）...
+      <div className="relative overflow-hidden rounded-2xl bg-gradient-to-br from-white to-sky-50 border border-slate-200 hover:border-sky-400 transition-all duration-300 shadow-lg hover:shadow-xl p-6">
+        <div className="text-sky-500 mb-4">{solution.icon}</div>
+        <h3 className="text-xl font-bold mb-2 text-slate-900">{solution.title}</h3>
+        <p className="text-slate-600 text-sm">{solution.description}</p>
+        <div className="mt-4 inline-flex items-center text-sky-600 font-semibold">
+          詳細を見る <ArrowRight className="w-4 h-4 ml-1" />
+        </div>
       </div>
     </div>
   ))}


### PR DESCRIPTION
## Summary
- render solution card content using icon, title, and description

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a578f76478832291a9d0dfff2e9f89