### PR TITLE
build: disable CI lint fail and upgrade Node

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
       
       - name: Install dependencies
@@ -34,6 +34,7 @@ jobs:
         run: npm run build
         env:
           PUBLIC_URL: /netsuite-landing
+          CI: false
       
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- use Node 20 in deploy workflow
- ignore ESLint warnings by setting `CI` to false in build step

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_b_68ac183884b48322b85c6cc232628a11