### PR TITLE
fix: resolve build errors and define package manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,5 +48,6 @@
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17"
-  }
+  },
+  "packageManager": "npm@11.4.2"
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,8 @@ const TermsOfUse = lazy(() => import('./TermsOfUse'));
 const SecurityPrivacy = lazy(() => import('./SecurityPrivacy'));
 const Services = lazy(() => import('./Services'));
 const CaseStudies = lazy(() => import('./CaseStudies'));
+const WhatIsNetSuite = lazy(() => import('./WhatIsNetSuite'));
+const EvangSolStrengths = lazy(() => import('./EvangSolStrengths'));
 
 const LoadingSpinner = () => (
   <div className="min-h-screen flex items-center justify-center">

--- a/src/EvangSolStrengths.tsx
+++ b/src/EvangSolStrengths.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const EvangSolStrengths: React.FC = () => (
+  <div className="p-8">
+    <h1 className="text-3xl font-bold mb-4">EvangSolの強み</h1>
+    <p>コンテンツは準備中です。</p>
+  </div>
+);
+
+export default EvangSolStrengths;

--- a/src/WhatIsNetSuite.tsx
+++ b/src/WhatIsNetSuite.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const WhatIsNetSuite: React.FC = () => (
+  <div className="p-8">
+    <h1 className="text-3xl font-bold mb-4">What is NetSuite?</h1>
+    <p>コンテンツは準備中です。</p>
+  </div>
+);
+
+export default WhatIsNetSuite;


### PR DESCRIPTION
## Summary
- specify npm as the project package manager
- add placeholder pages for WhatIsNetSuite and EvangSolStrengths
- register the new pages in the router

## Testing
- `npm test -- --passWithNoTests`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b133558c888322800e435cce1865c8