### PR TITLE
Set ComparisonHome as application root

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
-import App from './App';
+import ComparisonHome from './ComparisonHome';
+import { HashRouter as Router } from 'react-router-dom';
 import reportWebVitals from './reportWebVitals';
 
 const container = document.getElementById('root');
@@ -14,7 +15,9 @@ const root = ReactDOM.createRoot(container);
 
 root.render(
   <React.StrictMode>
-    <App />
+    <Router>
+      <ComparisonHome />
+    </Router>
   </React.StrictMode>
 );
 


### PR DESCRIPTION
## Summary
- render ComparisonHome as root component wrapped in HashRouter

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b14ebc9f348322935a505c12802417